### PR TITLE
feat: Display creation and modification times for posts and comments

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,8 +7,24 @@ app.use(express.json());
 
 // In-memory data store
 let posts = [
-    { id: 1, title: '첫 번째 게시물', content: '이것은 1번째 게시물입니다.', comments: [{id: 1, content: '첫 번째 댓글입니다.'}] },
-    { id: 2, title: '두 번째 게시물', content: '이것은 2번째 게시물입니다.', comments: [] }
+    {
+        id: 1,
+        title: '첫 번째 게시물',
+        content: '이것은 1번째 게시물입니다.',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        comments: [
+            {id: 1, content: '첫 번째 댓글입니다.', createdAt: new Date(), updatedAt: new Date()}
+        ]
+    },
+    {
+        id: 2,
+        title: '두 번째 게시물',
+        content: '이것은 2번째 게시물입니다.',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        comments: []
+    }
 ];
 let nextId = 3;
 let nextCommentId = 2;
@@ -17,7 +33,9 @@ let nextCommentId = 2;
 
 // GET all posts
 app.get('/api/posts', (req, res) => {
-    res.json(posts);
+    // Sort posts by creation date, newest first
+    const sortedPosts = posts.sort((a, b) => b.createdAt - a.createdAt);
+    res.json(sortedPosts);
 });
 
 // POST a new post
@@ -28,7 +46,15 @@ app.post('/api/posts', (req, res) => {
     if (!title || !content) {
         return res.status(400).json({ message: '제목과 내용은 필수입니다.' });
     }
-    const newPost = { id: nextId++, title, content, comments: [] };
+    const now = new Date();
+    const newPost = {
+        id: nextId++,
+        title,
+        content,
+        comments: [],
+        createdAt: now,
+        updatedAt: now
+    };
     posts.push(newPost);
     res.status(201).json(newPost);
 });
@@ -47,7 +73,12 @@ app.put('/api/posts/:id', (req, res) => {
         return res.status(400).json({ message: '제목과 내용은 필수입니다.' });
     }
 
-    posts[postIndex] = { ...posts[postIndex], title, content };
+    posts[postIndex] = {
+        ...posts[postIndex],
+        title,
+        content,
+        updatedAt: new Date()
+    };
     res.json(posts[postIndex]);
 });
 
@@ -78,8 +109,16 @@ app.post('/api/posts/:postId/comments', (req, res) => {
         return res.status(400).json({ message: '댓글 내용은 필수입니다.' });
     }
 
-    const newComment = { id: nextCommentId++, content };
+    const now = new Date();
+    const newComment = {
+        id: nextCommentId++,
+        content,
+        createdAt: now,
+        updatedAt: now
+    };
     post.comments.push(newComment);
+    // Sort comments by creation date, oldest first
+    post.comments.sort((a, b) => a.createdAt - b.createdAt);
     res.status(201).json(newComment);
 });
 
@@ -125,6 +164,7 @@ app.put('/api/posts/:postId/comments/:commentId', (req, res) => {
     }
 
     comment.content = content;
+    comment.updatedAt = new Date();
     res.json(comment);
 });
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -96,6 +96,19 @@ button:hover {
     font-size: 0.9em;
 }
 
+.post-meta {
+    font-size: 0.8em;
+    color: #666;
+    margin-top: 10px;
+    text-align: right;
+}
+
+.comment-meta {
+    font-size: 0.8em;
+    color: #888;
+    margin-top: 4px;
+}
+
 #posts-list li .post-actions .edit-btn {
     background-color: #28a745;
 }
@@ -184,8 +197,14 @@ button:hover {
     width: 100%;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start; /* Align items to the top */
     gap: 10px;
+}
+
+.comment-content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
 }
 
 .comment-view span, .comment-edit-form .edit-comment-input {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -40,29 +40,45 @@ document.addEventListener('DOMContentLoaded', () => {
             const li = document.createElement('li');
             li.setAttribute('data-id', post.id);
 
+            const postDate = new Date(post.createdAt);
+            const postDateString = formatDate(postDate);
+            const postUpdated = post.createdAt !== post.updatedAt;
+            const postUpdatedDateString = postUpdated ? `(수정됨: ${formatDate(new Date(post.updatedAt))})` : '';
+
             // Comments HTML
             const commentsHtml = `
                 <div class="comments-section">
                     <h4>댓글</h4>
                     <ul class="comments-list">
-                        ${post.comments.map(comment => `
-                            <li data-comment-id="${comment.id}">
-                                <div class="comment-view">
-                                    <span>${escapeHTML(comment.content)}</span>
-                                    <div class="comment-actions">
-                                        <button class="comment-edit-btn">수정</button>
-                                        <button class="comment-delete-btn">삭제</button>
+                        ${post.comments.map(comment => {
+                            const commentDate = new Date(comment.createdAt);
+                            const commentDateString = formatDate(commentDate);
+                            const commentUpdated = comment.createdAt !== comment.updatedAt;
+                            const commentUpdatedString = commentUpdated ? `(수정됨: ${formatDate(new Date(comment.updatedAt))})` : '';
+                            return `
+                                <li data-comment-id="${comment.id}">
+                                    <div class="comment-view">
+                                        <div class="comment-content">
+                                            <span>${escapeHTML(comment.content)}</span>
+                                            <div class="comment-meta">
+                                                <span class="comment-date">${commentDateString} ${commentUpdatedString}</span>
+                                            </div>
+                                        </div>
+                                        <div class="comment-actions">
+                                            <button class="comment-edit-btn">수정</button>
+                                            <button class="comment-delete-btn">삭제</button>
+                                        </div>
                                     </div>
-                                </div>
-                                <div class="comment-edit-form" style="display: none;">
-                                    <input type="text" class="edit-comment-input" value="${escapeHTML(comment.content)}">
-                                    <div class="comment-actions">
-                                        <button class="comment-save-btn">저장</button>
-                                        <button class="comment-cancel-btn">취소</button>
+                                    <div class="comment-edit-form" style="display: none;">
+                                        <input type="text" class="edit-comment-input" value="${escapeHTML(comment.content)}">
+                                        <div class="comment-actions">
+                                            <button class="comment-save-btn">저장</button>
+                                            <button class="comment-cancel-btn">취소</button>
+                                        </div>
                                     </div>
-                                </div>
-                            </li>
-                        `).join('')}
+                                </li>
+                            `;
+                        }).join('')}
                     </ul>
                     <form class="comment-form">
                         <input type="text" class="comment-input" placeholder="댓글을 입력하세요..." required>
@@ -74,6 +90,9 @@ document.addEventListener('DOMContentLoaded', () => {
             li.innerHTML = `
                 <h3>${escapeHTML(post.title)}</h3>
                 <p>${escapeHTML(post.content)}</p>
+                <div class="post-meta">
+                    <span class="post-date">작성일: ${postDateString} ${postUpdatedDateString}</span>
+                </div>
                 <div class="post-actions">
                     <button class="edit-btn">수정</button>
                     <button class="delete-btn">삭제</button>
@@ -312,6 +331,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const div = document.createElement('div');
         div.appendChild(document.createTextNode(str));
         return div.innerHTML;
+    }
+
+    function formatDate(date) {
+        return date.toLocaleString('ko-KR', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false,
+        });
     }
 
     // --- Initial Fetch ---


### PR DESCRIPTION
This commit implements the display of creation and modification timestamps for both posts and comments.

Backend (`server.js`):
- Added `createdAt` and `updatedAt` fields to post and comment objects.
- Timestamps are now set upon creation and updated upon modification.
- Posts are sorted by creation date (newest first), and comments are sorted by creation date (oldest first).

Frontend (`src/js/main.js`):
- The `renderPosts` function now displays the creation and modification dates for both posts and comments.
- A `formatDate` helper function is added for user-friendly date formatting.
- If a post or comment has been edited, the updated time is shown.

Styling (`src/css/style.css`):
- Added styles for the new timestamp metadata to ensure it is displayed clearly and fits into the existing design.